### PR TITLE
Feature: Automated install script for easy installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,9 @@
 # Include the license file
 include LICENSE
 
+# Include automated install scripts
+include setup.sh
+
 # Include the data files
 recursive-include puppeter *.py
 recursive-include puppeter *.pyi

--- a/README.rst
+++ b/README.rst
@@ -15,4 +15,32 @@ Puppeter - an automatic puppet installer
 
 A commandline tool to ease the installation of typical puppetserver - agent installation. It uses a interactive mode and batch mode as well. Batch mode utilizes a answer files for full automatic operation.
 
+Installation
+------------
+
+To install Puppeter simple use PIP:
+
+.. code-block:: bash
+
+  pip install puppeter
+
+If you like to install puppeter on clean operating system with automatic installer execute:
+
+.. code-block:: bash
+
+  curl https://raw.githubusercontent.com/coi-gov-pl/puppeter/master/setup.sh | bash
+
+It will install PIP and compatibile Python (2.7+)
+
+The installer script is supported for:
+
+* Debian 8
+* Debian 9
+* Ubuntu 14.04
+* Ubuntu 16.04
+* CentOS 6
+* CentOS 7
+* OracleLinux 6
+* OracleLinux 7
+
 **TODO: Write more later**

--- a/integration_tests/system-under-tests/debian/debian-8/Dockerfile
+++ b/integration_tests/system-under-tests/debian/debian-8/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:8
 
-RUN apt-get update && apt-get install -y openssh-server python-pip python-dev
+RUN apt-get update && apt-get install -y openssh-server
 RUN mkdir /var/run/sshd
 RUN echo 'root:phial' | chpasswd
 RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
@@ -10,6 +10,11 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
+
+COPY ./setup.sh /puppeter-setup.sh
+RUN chmod +x /puppeter-setup.sh
+ENV MODE dependencies
+RUN /puppeter-setup.sh
 
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]

--- a/integration_tests/system-under-tests/debian/debian-8/docker-compose.yml
+++ b/integration_tests/system-under-tests/debian/debian-8/docker-compose.yml
@@ -2,6 +2,8 @@
 version: '3'
 services:
   sut:
-    build: ./
+    build:
+      context: ../../../..
+      dockerfile: integration_tests/system-under-tests/debian/debian-8/Dockerfile
     ports:
       - 22

--- a/integration_tests/system-under-tests/debian/debian-9/Dockerfile
+++ b/integration_tests/system-under-tests/debian/debian-9/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:9
 
-RUN apt-get update && apt-get install -y openssh-server python-pip
+RUN apt-get update && apt-get install -y openssh-server
 RUN mkdir /var/run/sshd
 RUN echo 'root:phial' | chpasswd
 RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
@@ -10,6 +10,11 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
+
+COPY ./setup.sh /puppeter-setup.sh
+RUN chmod +x /puppeter-setup.sh
+ENV MODE dependencies
+RUN /puppeter-setup.sh
 
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]

--- a/integration_tests/system-under-tests/debian/debian-9/docker-compose.yml
+++ b/integration_tests/system-under-tests/debian/debian-9/docker-compose.yml
@@ -2,6 +2,8 @@
 version: '3'
 services:
   sut:
-    build: ./
+    build:
+      context: ../../../..
+      dockerfile: integration_tests/system-under-tests/debian/debian-9/Dockerfile
     ports:
       - 22

--- a/integration_tests/system-under-tests/debian/ubuntu-1404/Dockerfile
+++ b/integration_tests/system-under-tests/debian/ubuntu-1404/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-RUN apt-get update && apt-get install -y openssh-server python-pip python-dev
+RUN apt-get update && apt-get install -y openssh-server
 RUN mkdir /var/run/sshd
 RUN echo 'root:phial' | chpasswd
 RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
@@ -10,6 +10,11 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
+
+COPY ./setup.sh /puppeter-setup.sh
+RUN chmod +x /puppeter-setup.sh
+ENV MODE dependencies
+RUN /puppeter-setup.sh
 
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]

--- a/integration_tests/system-under-tests/debian/ubuntu-1404/docker-compose.yml
+++ b/integration_tests/system-under-tests/debian/ubuntu-1404/docker-compose.yml
@@ -2,6 +2,8 @@
 version: '3'
 services:
   sut:
-    build: ./
+    build:
+      context: ../../../..
+      dockerfile: integration_tests/system-under-tests/debian/ubuntu-1404/Dockerfile
     ports:
       - 22

--- a/integration_tests/system-under-tests/debian/ubuntu-1604/Dockerfile
+++ b/integration_tests/system-under-tests/debian/ubuntu-1604/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y openssh-server python-pip
+RUN apt-get update && apt-get install -y openssh-server
 RUN mkdir /var/run/sshd
 RUN echo 'root:phial' | chpasswd
 RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
@@ -10,6 +10,11 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
+
+COPY ./setup.sh /puppeter-setup.sh
+RUN chmod +x /puppeter-setup.sh
+ENV MODE dependencies
+RUN /puppeter-setup.sh
 
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]

--- a/integration_tests/system-under-tests/debian/ubuntu-1604/docker-compose.yml
+++ b/integration_tests/system-under-tests/debian/ubuntu-1604/docker-compose.yml
@@ -2,6 +2,8 @@
 version: '3'
 services:
   sut:
-    build: ./
+    build:
+      context: ../../../..
+      dockerfile: integration_tests/system-under-tests/debian/ubuntu-1604/Dockerfile
     ports:
       - 22

--- a/integration_tests/system-under-tests/redhat/centos-6/Dockerfile
+++ b/integration_tests/system-under-tests/redhat/centos-6/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos:6
 
+RUN yum install -y openssh-server
 RUN mkdir /var/run/sshd
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
 RUN echo 'root:phial' | chpasswd

--- a/integration_tests/system-under-tests/redhat/centos-6/Dockerfile
+++ b/integration_tests/system-under-tests/redhat/centos-6/Dockerfile
@@ -1,9 +1,5 @@
 FROM centos:6
 
-RUN yum install -y centos-release-scl
-RUN yum install -y openssh-server python27-python-pip
-ADD enablepython27.sh /etc/profile.d/enablepython27.sh
-
 RUN mkdir /var/run/sshd
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
 RUN echo 'root:phial' | chpasswd
@@ -14,6 +10,11 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
+
+COPY ./setup.sh /puppeter-setup.sh
+RUN chmod +x /puppeter-setup.sh
+ENV MODE dependencies
+RUN /puppeter-setup.sh
 
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]

--- a/integration_tests/system-under-tests/redhat/centos-6/docker-compose.yml
+++ b/integration_tests/system-under-tests/redhat/centos-6/docker-compose.yml
@@ -2,6 +2,8 @@
 version: '3'
 services:
   sut:
-    build: ./
+    build:
+      context: ../../../..
+      dockerfile: integration_tests/system-under-tests/redhat/centos-6/Dockerfile
     ports:
       - 22

--- a/integration_tests/system-under-tests/redhat/centos-6/enablepython27.sh
+++ b/integration_tests/system-under-tests/redhat/centos-6/enablepython27.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-source /opt/rh/python27/enable

--- a/integration_tests/system-under-tests/redhat/centos-7/Dockerfile
+++ b/integration_tests/system-under-tests/redhat/centos-7/Dockerfile
@@ -1,7 +1,5 @@
 FROM centos:7
 
-RUN yum install -y epel-release
-RUN yum install -y openssh-server python-pip
 RUN mkdir /var/run/sshd
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
 RUN echo 'root:phial' | chpasswd
@@ -12,6 +10,11 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
+
+COPY ./setup.sh /puppeter-setup.sh
+RUN chmod +x /puppeter-setup.sh
+ENV MODE dependencies
+RUN /puppeter-setup.sh
 
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]

--- a/integration_tests/system-under-tests/redhat/centos-7/Dockerfile
+++ b/integration_tests/system-under-tests/redhat/centos-7/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos:7
 
+RUN yum install -y openssh-server
 RUN mkdir /var/run/sshd
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
 RUN echo 'root:phial' | chpasswd

--- a/integration_tests/system-under-tests/redhat/centos-7/docker-compose.yml
+++ b/integration_tests/system-under-tests/redhat/centos-7/docker-compose.yml
@@ -2,6 +2,8 @@
 version: '3'
 services:
   sut:
-    build: ./
+    build:
+      context: ../../../..
+      dockerfile: integration_tests/system-under-tests/redhat/centos-7/Dockerfile
     ports:
       - 22

--- a/integration_tests/system-under-tests/redhat/oraclelinux-6/Dockerfile
+++ b/integration_tests/system-under-tests/redhat/oraclelinux-6/Dockerfile
@@ -1,5 +1,6 @@
 FROM oraclelinux:6
 
+RUN yum install -y openssh-server
 RUN mkdir /var/run/sshd
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
 RUN echo 'root:phial' | chpasswd

--- a/integration_tests/system-under-tests/redhat/oraclelinux-6/Dockerfile
+++ b/integration_tests/system-under-tests/redhat/oraclelinux-6/Dockerfile
@@ -1,9 +1,5 @@
 FROM oraclelinux:6
 
-RUN yum-config-manager --enable public_ol6_software_collections
-RUN yum install -y openssh-server python27-python-pip
-ADD enablepython27.sh /etc/profile.d/enablepython27.sh
-
 RUN mkdir /var/run/sshd
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
 RUN echo 'root:phial' | chpasswd
@@ -14,6 +10,11 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
+
+COPY ./setup.sh /puppeter-setup.sh
+RUN chmod +x /puppeter-setup.sh
+ENV MODE dependencies
+RUN /puppeter-setup.sh
 
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]

--- a/integration_tests/system-under-tests/redhat/oraclelinux-6/docker-compose.yml
+++ b/integration_tests/system-under-tests/redhat/oraclelinux-6/docker-compose.yml
@@ -2,6 +2,8 @@
 version: '3'
 services:
   sut:
-    build: ./
+    build:
+      context: ../../../..
+      dockerfile: integration_tests/system-under-tests/redhat/oraclelinux-6/Dockerfile
     ports:
       - 22

--- a/integration_tests/system-under-tests/redhat/oraclelinux-6/enablepython27.sh
+++ b/integration_tests/system-under-tests/redhat/oraclelinux-6/enablepython27.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-source /opt/rh/python27/enable

--- a/integration_tests/system-under-tests/redhat/oraclelinux-7/Dockerfile
+++ b/integration_tests/system-under-tests/redhat/oraclelinux-7/Dockerfile
@@ -1,7 +1,5 @@
 FROM oraclelinux:7
 
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y openssh-server python-pip
 RUN mkdir /var/run/sshd
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
 RUN echo 'root:phial' | chpasswd
@@ -14,6 +12,11 @@ ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
 
 ENV LANG en_US.UTF-8
+
+COPY ./setup.sh /puppeter-setup.sh
+RUN chmod +x /puppeter-setup.sh
+ENV MODE dependencies
+RUN /puppeter-setup.sh
 
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]

--- a/integration_tests/system-under-tests/redhat/oraclelinux-7/Dockerfile
+++ b/integration_tests/system-under-tests/redhat/oraclelinux-7/Dockerfile
@@ -1,5 +1,6 @@
 FROM oraclelinux:7
 
+RUN yum install -y openssh-server
 RUN mkdir /var/run/sshd
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
 RUN echo 'root:phial' | chpasswd

--- a/integration_tests/system-under-tests/redhat/oraclelinux-7/docker-compose.yml
+++ b/integration_tests/system-under-tests/redhat/oraclelinux-7/docker-compose.yml
@@ -2,6 +2,8 @@
 version: '3'
 services:
   sut:
-    build: ./
+    build:
+      context: ../../../..
+      dockerfile: integration_tests/system-under-tests/redhat/oraclelinux-7/Dockerfile
     ports:
       - 22

--- a/setup.sh
+++ b/setup.sh
@@ -76,7 +76,7 @@ if [ $osfamily == redhat ]; then
       run yum-config-manager --enable public_ol6_software_collections
       run yum install -y python27-python-pip
     fi
-    echo 'source /opt/rh/python27/enable' >> ~/.profile
+    echo 'source /opt/rh/python27/enable' >> /etc/profile.d/python27.sh
     run source /opt/rh/python27/enable
 elif [ $majversion == 7 ]; then
     if [ $os == centos ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -e
+
+# https://regex101.com/r/Uvm9bs/2
+RHEL_SED_VERSION_PARSE='s/^[^0-9]+([0-9]+\.[0-9]+).*$/\1/'
+COLOR_NC='\e[0m' # No Color
+COLOR_LIGHT_BLUE='\e[1;34m'
+COLOR_LIGHT_RED='\e[1;31m'
+COLOR_LIGHT_GREEN='\e[1;32m'
+RUN=${RUN:-1}
+DEBUG=${DEBUG:-0}
+SUDO=${SUDO:-1}
+APT_UPDATE_INTERVAL=${APT_UPDATE_INTERVAL:-7200}
+MODE=${MODE:-puppeter}
+
+if [ $DEBUG == 1 ]; then
+  set -x
+fi
+
+if [ -f /etc/redhat-release ]; then
+  if [ -f /etc/oracle-release ]; then
+    os=oraclelinux
+    version=$(cat /etc/oracle-release | sed -E $RHEL_SED_VERSION_PARSE)
+  elif [ -f /etc/centos-release ]; then
+    os=centos
+    version=$(cat /etc/centos-release | sed -E $RHEL_SED_VERSION_PARSE)
+  else
+    os=rhel
+    version=$(cat /etc/redhat-release | sed -E $RHEL_SED_VERSION_PARSE)
+  fi
+  osfamily=redhat
+elif [ -f /etc/debian_version ]; then
+  osfamily=debian
+  if [ -f /etc/lsb-release ]; then
+    source /etc/lsb-release
+    os=$(echo $DISTRIB_ID | tr '[:upper:]' '[:lower:]')
+    version=$DISTRIB_RELEASE
+  else
+    os=debian
+    version=$(cat /etc/debian_version)
+  fi
+fi
+majversion=$(echo $version | cut -d. -f1)
+
+run() {
+  command="$@"
+  if [[ $EUID -ne 0 ]] && [ $SUDO == 1 ]; then
+    command="sudo -i ${command}"
+  fi
+  echo -e "${COLOR_LIGHT_BLUE}Executing: ${command}${COLOR_NC}"
+  if [ $RUN == 1 ]; then
+    eval "$command"
+  fi
+}
+
+unsupported() {
+  echo -e "${COLOR_LIGHT_RED}Unsupported operating system: ${os} ${version}${COLOR_NC}" 1>&2
+  exit 1
+}
+
+last_aptget_update() {
+    local apt_date="$(stat -c %Y '/var/cache/apt')"
+    local now_date="$(date +'%s')"
+
+    echo $((now_date - apt_date))
+}
+
+if [ $osfamily == redhat ]; then
+  if [ $majversion == 6 ]; then
+    if [ $os == centos ]; then
+      run yum install -y centos-release-scl
+      run yum install -y python27-python-pip
+    fi
+    if [ $os == oraclelinux ]; then
+      run yum-config-manager --enable public_ol6_software_collections
+      run yum install -y python27-python-pip
+    fi
+    echo 'source /opt/rh/python27/enable' >> ~/.profile
+    run source /opt/rh/python27/enable
+elif [ $majversion == 7 ]; then
+    if [ $os == centos ]; then
+      run yum install -y epel-release
+      run yum install -y python-pip
+    fi
+    if [ $os == oraclelinux ]; then
+      run yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+      run yum install -y python-pip
+    fi
+  else
+    unsupported
+  fi
+elif [ $osfamily == debian ]; then
+  flavor="$os-$majversion"
+  if [[ "$(last_aptget_update)" -gt $APT_UPDATE_INTERVAL ]]; then
+    run apt-get update -m
+  fi
+  if [ $flavor == ubuntu-14 ] || [ $flavor == debian-8 ]; then
+    run apt-get install -y python-pip python-dev
+  else
+    run apt-get install -y python-pip
+  fi
+fi
+if [ $MODE == puppeter ]; then
+  run pip install puppeter
+fi


### PR DESCRIPTION
This automated script will be useful for users that want automatic, cross-platform install method of Puppeter tool. It's also planed to be used by `beaker-puppeter` module I'm currently working on.

Usage: 

    curl https://raw.githubusercontent.com/coi-gov-pl/puppeter/master/setup.sh | bash

PS. Link will be working after next release of Puppeter